### PR TITLE
Initialize driver in COMMAND mode and make sure it will be in DATA mode

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -99,7 +99,7 @@ void Task::restoreFactorySettings(void)
 bool Task::configureHook()
 {
     // Creating the driver object
-    driver.reset(new Driver());
+    driver.reset(new Driver(COMMAND));
     if (!_io_port.get().empty())
         driver->openURI(_io_port.get());
     setDriver(driver.get());
@@ -111,14 +111,19 @@ bool Task::configureHook()
     // Set interface
     driver->setInterface(_interface.get());
 
+    // Switch device to data mode.
+    // If device is already in data mode, it will send the command 'ATO' it as raw data
+    // It makes sure the device is in DATA mode
+    driver->switchToDataMode();
+    sleep(1);
+    //Set operation mode. Default DATA mode.
+    if(driver->getMode() != _mode.get())
+        driver->setOperationMode(_mode.get());
+
     driver->resetDevice(SEND_BUFFER, true);
 
      // Set System Time for current Time.
     driver->setSystemTimeNow();
-
-    //Set operation mode. Default DATA mode.
-    if(driver->getMode() != _mode.get())
-        driver->setOperationMode(_mode.get());
 
     // Initialize source level parameters
     updateDynamicProperties();

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -115,7 +115,6 @@ bool Task::configureHook()
     // If device is already in data mode, it will send the command 'ATO' it as raw data
     // It makes sure the device is in DATA mode
     driver->switchToDataMode();
-    sleep(1);
     //Set operation mode. Default DATA mode.
     if(driver->getMode() != _mode.get())
         driver->setOperationMode(_mode.get());


### PR DESCRIPTION
Send `ATO` in command mode will guarantee that the device will be in DATA mode.
If the device is in DATA mode, it will be transmitted as burst data (no `+++AT`)
and as this command does not require a response, it doesn't break the task.