### PR TITLE
Annoying bug in usbl

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -235,6 +235,11 @@ void Task::errorHook()
 void Task::stopHook()
 {
     driver->resetDevice(SEND_BUFFER, true);
+    if(state() == EXCEPTION)
+    {
+       RTT::log(RTT::Info) << "Usbl_evologics Task.cpp. Recover from exception." << RTT::endlog();
+       recover();
+    }
     TaskBase::stopHook();
 }
 void Task::cleanupHook()

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -70,13 +70,13 @@ bool Task::setSource_level_control(bool value)
 // Reset Device to stored settings and restart it.
 void Task::resetDevice(void)
 {
-    driver->resetDevice(DEVICE);
+    driver->resetDevice(DEVICE, true);
 }
 
 // Clear the transmission buffer - drop raw data and instant message
 void Task::clearTransmissionBuffer(void)
 {
-    driver->resetDevice(SEND_BUFFER);
+    driver->resetDevice(SEND_BUFFER, true);
 }
 
 // Store current settings.
@@ -164,7 +164,7 @@ bool Task::startHook()
         return false;
 
     last_status = base::Time::now();
-    driver->resetDevice(SEND_BUFFER);
+    driver->resetDevice(SEND_BUFFER, true);
 
     cout << "USBL working" << endl;
 
@@ -234,7 +234,7 @@ void Task::errorHook()
 }
 void Task::stopHook()
 {
-    driver->resetDevice(SEND_BUFFER);
+    driver->resetDevice(SEND_BUFFER, true);
     TaskBase::stopHook();
 }
 void Task::cleanupHook()


### PR DESCRIPTION
Ignore old responses when calling [resetDevice](https://github.com/Brazilian-Institute-of-Robotics/drivers-usbl_evologics/blob/master/src/Driver.cpp#L654).
In stopHook, recover from exception state.

Fix this kind of [bug](https://github.com/Brazilian-Institute-of-Robotics/testlogbook_data/blob/master/tests/20170406/_posts/2017-04-06-180835-JA.md). It is hard to reproduce this error and to track its origin.
