### PR TITLE
Do not keep raw data in the internal queue

### DIFF
--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -338,6 +338,18 @@ namespace usbl_evologics {
          * @param reason to be dropped.
          */
         void outputDroppedData(iodrivers_base::RawPacket const& dropped_data, std::string const &reason);
+
+        /** Drop one raw data from queue
+         *
+         * @param connection gives the reasoni for dropping
+         */
+        void dropData(AcousticConnection const& connection);
+
+        /** update State according connection status
+         *
+         * @param connection check connection and free buffer
+         */
+        void updateState(AcousticConnection const& connection);
     };
 }
 

--- a/usbl_evologics.orogen
+++ b/usbl_evologics.orogen
@@ -100,7 +100,8 @@ task_context "Task" do
    # Restore Factory Settings.
    operation('restoreFactorySettings')
   
-   runtime_states   :HUGE_RAW_DATA_INPUT, :HUGE_INSTANT_MESSAGE, :FULL_RAW_DATA_QUEUE, :FULL_IM_QUEUE
+   runtime_states   :HUGE_RAW_DATA_INPUT, :HUGE_INSTANT_MESSAGE, :FULL_RAW_DATA_QUEUE,
+                    :FULL_IM_QUEUE, :FULL_USBL_BUFFER, :UNEXPECTED_ACOUSTIC_CONNECTION
    exception_states :DEVICE_INTERNAL_ERROR, :MALICIOUS_SEQUENCE_IN_RAW_DATA, :OLD_ACK
 
    port_driven


### PR DESCRIPTION
If the transmission to the usbl is not possible, drop it.
The usbl has an internal buffer for it.

Track reason for dropping data and the acoustic connection